### PR TITLE
Added autorun info & resize event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Node.js server that automatically rotates between multiple p5.js sketches usin
    npm start
    ```
 
-3. Open your browser to http://localhost:3333
+3. Open your browser to <http://localhost:3333>
 
 ## Project Structure
 
@@ -73,3 +73,35 @@ The `config.json` file controls the server settings and sketch rotation:
 
 1. Create a new directory in `public/sketches/` with your sketch files
 2. Add the sketch information to the `sketches` array in `config.json`
+
+## Autorun Setup
+
+1. Edit the content of `com.p5switcher.plist` to point to this folder on your system.
+1. Copy the LaunchAgent file to your system
+
+```bash
+# Copy the plist file to your LaunchAgents directory
+cp ./autorun-setup/com.p5switcher.plist ~/Library/LaunchAgents/
+```
+
+3. Load the LaunchAgent
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.p5switcher.plist
+```
+
+4. Verify it's working
+
+```bash
+# Check if it's loaded
+launchctl list | grep com.p5switcher
+
+# Manually start it to test
+launchctl start com.p5switcher
+```
+
+5. To stop the service and autorun, you can unload the LaunchAgent:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.p5switcher.plist
+```

--- a/autorun-setup/com.p5switcher.plist
+++ b/autorun-setup/com.p5switcher.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ajr.p5switcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/osascript</string>
+        <string>-e</string>
+        <string>tell application "Terminal" to do script "cd YOUR_LOCAL_FOLDER/p5-switcher && npm run dev"</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,16 @@
         document.getElementById('sketch-title').textContent = sketch.title;
         document.getElementById('creator-name').textContent = sketch.name;
       });
+
+      window.addEventListener('resize', () => {
+        // Refresh the iframe content
+        if (frame.src) {
+          frame.contentWindow.location.reload();
+        }
+        frame.style.width = `${window.innerWidth}px`;
+        frame.style.height = `${window.innerHeight}px`;
+        console.log('Frame resized to:', frame.style.width, frame.style.height);
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
This pull request includes updates to the `README.md` file, the addition of an autorun setup using a LaunchAgent plist file, and improvements to the `public/index.html` file to handle window resizing. The most important changes include adding instructions for autorun setup, updating the server's browser access URL, and implementing iframe resizing on window resize events.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19): Updated the server access URL to use angle brackets and added detailed instructions for setting up autorun using a LaunchAgent plist file. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76-R107)

Autorun setup:

* [`autorun-setup/com.p5switcher.plist`](diffhunk://#diff-3e048096ffa9fd66ed00d25969d4eb6b46544ab230c2975cbe958991a857e1d1R1-R16): Added a new plist file to automatically start the server using macOS LaunchAgent.

Enhancements to user interface:

* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR64-R73): Added an event listener to handle window resize events, refreshing the iframe content and adjusting its dimensions accordingly.